### PR TITLE
Suppress deprecation warning.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ checkerFramework {
     '-Werror',
     '-AcheckPurityAnnotations',
     '-ArequirePrefixInWarningSuppressions',
-    '-AwarnUnneededSuppressions'
+    '-AwarnUnneededSuppressions',
+    '-Xlint:deprecation'
   ]
 }
 

--- a/src/main/java/org/plumelib/htmlprettyprint/HtmlPrettyPrint.java
+++ b/src/main/java/org/plumelib/htmlprettyprint/HtmlPrettyPrint.java
@@ -34,6 +34,7 @@ public final class HtmlPrettyPrint {
       String url = "file://" + f.getAbsolutePath();
 
       try {
+        @SuppressWarnings("deprecation") // deprecated in Java 9.
         XMLReader tagsoup = XMLReaderFactory.createXMLReader("org.ccil.cowan.tagsoup.Parser");
         Builder parser = new Builder(tagsoup);
 


### PR DESCRIPTION
[XMLReaderFactory](https://docs.oracle.com/javase/9/docs/api/org/xml/sax/helpers/XMLReaderFactory.html) was deprecated in Java 9.  Instead of suppressing the warning, [SAXParserFactory](https://docs.oracle.com/javase/9/docs/api/javax/xml/parsers/SAXParserFactory.html) could be used instead.